### PR TITLE
Fix error when priceCur is null.

### DIFF
--- a/jobs/update-prices-tm.js
+++ b/jobs/update-prices-tm.js
@@ -63,7 +63,9 @@ module.exports = async () => {
                     }
 
                     const traderPrice = i2
-                    const price = traderPrice['priceCur']
+                    const price = traderPrice['priceCur'] || traderPrice['price'];
+                    if (price == null) continue;
+
                     var currencySymbol = traderPrice['cur']
                     const trader = traderPrice['trader'].toLowerCase()
                     const level = traderPrice['level']


### PR DESCRIPTION
When priceCur is null use price. If both are null continue loop so we don't log an empty price.