### PR TITLE
Change scan timeout for TM.

### DIFF
--- a/jobs/check-scans.js
+++ b/jobs/check-scans.js
@@ -35,7 +35,10 @@ module.exports = async () => {
 
             if (lastScanAge < 1800) {
                 continue;
-            }
+            } else if (lastScanAge < 14400 && source == 'tm') {
+                //TM prices only update every 3 hours.
+                continue;
+            }            
 
             const messageData = {
                 title: `Missing scans from ${encodeURIComponent(result.source)}`,


### PR DESCRIPTION
The TM prices only sync every 3 hours, and we were checking for missing prices after 30 minutes, which results in a lot of false alerts.