### PR TITLE
Fix exessive reads for update-trader-prices.js

### DIFF
--- a/jobs/update-prices-tm.js
+++ b/jobs/update-prices-tm.js
@@ -107,6 +107,10 @@ module.exports = async () => {
                         //Item already exists, lets get ID and push price update.
                         const traderItemID = dbTraderItem[0]['id']
 
+                        doQuery(`
+                            UPDATE trader_items SET timestamp = '${timestamp}' WHERE id = '${traderItemID}'
+                        `)
+
                         await doQuery(`
                                 INSERT INTO trader_price_data (trade_id, price, source, timestamp)
                                 SELECT '${traderItemID}', ${price}, 'tm', '${timestamp}'

--- a/jobs/update-prices-tt.js
+++ b/jobs/update-prices-tt.js
@@ -132,6 +132,10 @@ module.exports = async () => {
                     //Item already exists, lets get ID and push price update.
                     const traderItemID = dbTraderItem[0]['id']
 
+                    doQuery(`
+                        UPDATE trader_items SET timestamp = '${timestamp}' WHERE id = '${traderItemID}'
+                    `)
+
                     await doQuery(`
                                     INSERT INTO trader_price_data (trade_id, price, source, timestamp)
                                     SELECT '${traderItemID}', ${price}, 'tt', '${timestamp}'


### PR DESCRIPTION
Forgot to update trader_items timestamp which was resulting in huge row reads from the trader_price_data table.